### PR TITLE
remove link to old volunteer form, add link to current

### DIFF
--- a/events/2024/volunteer.md
+++ b/events/2024/volunteer.md
@@ -2,8 +2,5 @@
 layout: page
 title: "Volunteer"
 ---
-BSides PDX doesn't happen without the help of community members volunteering their time. We greatly appreciate our volunteers.
 
-You can find details about volunteer roles on [this page](../../about/volunteer-info.html)
-
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSd5T0Zj643McsuOjA_BtrXKQtypv5IGtbdRk7GtD_WzWuIOAw/viewform?embedded=true" width="640" height="1070" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+Thanks to everyone who volunteered and made BSides PDX 2024 a success.  Information about volunteering in 2025 can be found [here](../2025/volunteer.html)


### PR DESCRIPTION
Removes the link to the old volunteer form and replaces it with a link to the 2025 form.